### PR TITLE
Handle Sense pin in an open-collector fashion

### DIFF
--- a/config.h
+++ b/config.h
@@ -61,7 +61,7 @@
  * floating when no keys are pressed. This means that the pin should be driven in an open-collector fashion, otherwise
  * it can create problems, in particular on the Plus/4 where the Sense line is shared with data pin 2 of the User Port.
  *
- * This could be compensated in hardware (put a diode in series, cathode to computer side) or in software, by taking
+ * This could be compensated in hardware (put a diode in series, cathode to Arduino side) or in software, by taking
  * advantage of the way ATmega pins are configured, which is what we do here:
  * - To set sense "high" we set the pin to input mode, pin will go Hi-Z and basically float
  * - To set it low, we switch to output mode which will implicitly be low (PORTD defaults to 0 and we never touch it)

--- a/config.h
+++ b/config.h
@@ -45,12 +45,6 @@
 #define TWI_PIN_SCL         5
 
 // port definitions, change for different wiring
-#define SENSE_PORT          PORTD
-#define SENSE_DDR           DDRD
-#define SENSE_PIN           5
-#define SENSE_ON()          SENSE_PORT &= ~_BV(SENSE_PIN)
-#define SENSE_OFF()         SENSE_PORT |=  _BV(SENSE_PIN)
-
 #define TAPE_READ_PORT      PORTD
 #define TAPE_READ_DDR       DDRD
 #define TAPE_READ_PIN       3
@@ -62,6 +56,21 @@
 #define TAPE_WRITE_DDR      DDRB
 #define TAPE_WRITE_PINS     PINB
 #define TAPE_WRITE_PIN      0
+
+/* The Sense pin on the original Datassette is a physical switch that only grounds the line when pressed, it's left
+ * floating when no keys are pressed. This means that the pin should be driven in an open-collector fashion, otherwise
+ * it can create problems, in particular on the Plus/4 where the Sense line is shared with data pin 2 of the User Port.
+ *
+ * This could be compensated in hardware (put a diode in series, cathode to computer side) or in software, by taking
+ * advantage of the way ATmega pins are configured, which is what we do here:
+ * - To set sense "high" we set the pin to input mode, pin will go Hi-Z and basically float
+ * - To set it low, we switch to output mode which will implicitly be low (PORTD defaults to 0 and we never touch it)
+ */
+#define SENSE_PORT          PORTD
+#define SENSE_DDR           DDRD
+#define SENSE_PIN           5
+#define SENSE_ON()          SENSE_DDR |= _BV(SENSE_PIN)
+#define SENSE_OFF()         SENSE_DDR &= ~_BV(SENSE_PIN)
 
 #define MOTOR_PORT          PORTD
 #define MOTOR_DDR           DDRD

--- a/tapuino.c
+++ b/tapuino.c
@@ -648,8 +648,7 @@ int tapuino_hardware_setup(void)
   TWI_PORT |= _BV(TWI_PIN_SDA);
   TWI_PORT |= _BV(TWI_PIN_SCL);
     
-  // sense is output to C64
-  SENSE_DDR |= _BV(SENSE_PIN);
+  // sense is output to C64 but it works in an open-collector fashion, so no need to set DDR, just make sure it is off
   SENSE_OFF();
   
   // read is output to C64


### PR DESCRIPTION
The _Sense_ pin on the original Datassette is a physical switch that only grounds the line when pressed, it's left floating when no keys are pressed. This means that the pin should be driven in an open-collector fashion, otherwise it can create problems, in particular on the Plus/4 where the Sense line is shared with data pin 2 of the User Port.

This could be compensated in hardware (put a diode in series, cathode to Arduino side) or in software, by taking advantage of the way ATmega pins are configured, which is what we do here:
- To set sense "high" we set the pin to input mode, pin will go Hi-Z and basically float (it will be pulled up on the computer side)
- To set it low, we switch to output mode which will implicitly be low (PORTD defaults to 0 and we never touch it)

This change is tested and working on Plus/4.